### PR TITLE
Cleanup dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,14 @@
   "type": "library",
   "require": {
     "php": "^7.4 || ^8.0",
+    "ext-json": "*",
     "php-http/discovery": "^1.15",
-    "php-http/httplug": "^2.3",
-    "php-http/client-common": "^2.6",
-    "ext-json": "*"
+    "psr/http-client-implementation": "*",
+    "psr/http-factory-implementation": "*"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.16",
     "guzzlehttp/guzzle": "^7.5",
-    "http-interop/http-factory-guzzle": "^1.2",
     "phpstan/phpstan": "^1.10",
     "phpunit/phpunit": "^9.5"
   },
@@ -29,13 +28,9 @@
       "email": "hello@joppe.dev"
     }
   ],
-  "suggest": {
-    "guzzlehttp/guzzle": "Use Guzzle ^7 as HTTP client",
-    "http-interop/http-factory-guzzle": "Factory for guzzlehttp/guzzle"
-  },
   "config": {
     "allow-plugins": {
-      "php-http/discovery": true
+      "php-http/discovery": false
     }
   },
   "scripts": {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JoppeDc\LogsnagPhpSdk\Http;
 
-use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr17Factory;
 use Http\Discovery\Psr18ClientDiscovery;
 use JoppeDc\LogsnagPhpSdk\Contracts\Http;
 use JoppeDc\LogsnagPhpSdk\Exceptions\ApiException;
@@ -43,8 +43,8 @@ class Client implements Http
         $this->baseUrl = $url;
         $this->apiKey = $apiKey;
         $this->http = $httpClient ?? Psr18ClientDiscovery::find();
-        $this->requestFactory = $reqFactory ?? Psr17FactoryDiscovery::findRequestFactory();
-        $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
+        $this->requestFactory = $reqFactory ?? new Psr17Factory();
+        $this->streamFactory = $streamFactory ?? ($this->requestFactory instanceof StreamFactoryInterface ? $this->requestFactory : new Psr17Factory());
 
         $this->headers = array_filter([
             'User-Agent' => implode(';', array_merge($clientAgents, [Logsnag::qualifiedVersion()])),


### PR DESCRIPTION
Many httplug-related deps are not needed, the "suggest" entry is not needed either because `php-http/discovery` will install what's needed, thanks to the added `*-implementation` deps.